### PR TITLE
replace parsing of description with proper supported JSDoc types

### DIFF
--- a/src/create-react.ts
+++ b/src/create-react.ts
@@ -77,7 +77,10 @@ export const createReactWrapperMetadata = (metadata: Record<string, unknown>, pr
     const sourceName = path.parse(component.modulePath).name;
     const importPath = getComponentPath(sourceName);
     const events = (component.events || []).map(createEvent).join(",\n");
-    const imports = (component.events || []).map(event => event.type.text).join(",");
+    const imports = (component.events || [])
+      .filter(event => !event.type.text.startsWith('CustomEvent'))
+      .map(event => event.type.text)
+      .join(",");
 
     const componentName = pascalCase(tagWithoutPrefix);
 


### PR DESCRIPTION
Currently the plugin parses the description of the event to get the typing. JSDoc has a default way of Types looking like this:
```typescript
/**
 * @event {CustomEvent<any[]>} my-event - fired when foo
 */
```
This is supported by the custom-elements-manifest and will lead to the following event definition:
```json
{
  "events": [
    {
      "name": "my-event",
      "type": {
        "text": "CustomEvent<any[]>"
      },
      "description": "fired when foo",
    }
  ],
}
```